### PR TITLE
GA: Harry S Truman Parkway extension

### DIFF
--- a/hwy_data/GA/usasf/ga.hartrupkwy.wpt
+++ b/hwy_data/GA/usasf/ga.hartrupkwy.wpt
@@ -1,11 +1,13 @@
-GA204Spr http://www.openstreetmap.org/?lat=31.973316&lon=-81.105655
+GA204 http://www.openstreetmap.org/?lat=31.979113&lon=-81.137820
+WhiBluRd http://www.openstreetmap.org/?lat=31.977157&lon=-81.131732
+GA204Spr http://www.openstreetmap.org/?lat=31.973507&lon=-81.105693
 +X000 http://www.openstreetmap.org/?lat=31.975473&lon=-81.096900
 MonCroRd http://www.openstreetmap.org/?lat=31.990079&lon=-81.083372
 EisDr http://www.openstreetmap.org/?lat=32.000670&lon=-81.079252
 GA21 http://www.openstreetmap.org/?lat=32.022686&lon=-81.088361
 DeLAve http://www.openstreetmap.org/?lat=32.034683&lon=-81.083586
 US80 http://www.openstreetmap.org/?lat=32.043796&lon=-81.069628
-EHenSt http://www.openstreetmap.org/?lat=32.056536&lon=-81.072568
+HenSt +EHenSt http://www.openstreetmap.org/?lat=32.056536&lon=-81.072568
 +X001 http://www.openstreetmap.org/?lat=32.062646&lon=-81.072460
 +X002 http://www.openstreetmap.org/?lat=32.067020&lon=-81.076366
-EPreSt http://www.openstreetmap.org/?lat=32.073311&lon=-81.073308
+PreSt +EPreSt http://www.openstreetmap.org/?lat=32.073311&lon=-81.073308


### PR DESCRIPTION
http://clinched.s2.bizhat.com/viewtopic.php?t=2290&mforum=clinched

15-08-18;(USA) Georgia;Harry S Truman Parkway;ga.hartrupkwy;Extended westward from the interchange with GA 204 Spur (Whitfield Avenue) in Savannah to a new intersection with GA 204 (Abercorn Street).